### PR TITLE
Duplicando item ao fazer a edição.

### DIFF
--- a/app/src/main/java/br/com/dio/todolist/datasource/TaskDataSource.kt
+++ b/app/src/main/java/br/com/dio/todolist/datasource/TaskDataSource.kt
@@ -11,7 +11,8 @@ object TaskDataSource {
         if (task.id == 0) {
             list.add(task.copy(id = list.size + 1))
         } else {
-            list.remove(task)
+            val taskToRemove = list.find { task.id == it.id }
+            list.remove(taskToRemove)
             list.add(task)
         }
     }

--- a/app/src/main/java/br/com/dio/todolist/model/Task.kt
+++ b/app/src/main/java/br/com/dio/todolist/model/Task.kt
@@ -5,19 +5,4 @@ data class Task(
     val hour: String,
     val date: String,
     val id: Int = 0
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Task
-
-        if (id != other.id) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return id
-    }
-}
+)


### PR DESCRIPTION
O problema estava acontecendo pois com o `equals` e `hash code` que temos hoje o `Kotlin` não conseguiu reconhecer como o mesmo objeto, então nunca removia o item da lista logo causava duplicidade.

Para solucionar o problema eu usei o método `find` das `collections` para buscar na lista a `Task` com o id da task que estamos recebendo e removendo quando achamos o mesmo. E deixei o `equals` e `hash code` padrão da `DataClass`.